### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR
Created a new Express server with a mock activity feed endpoint

### What changed?
- Created a new Express server implementation in `server.js`
- Added a `/feed` endpoint that returns mock activity data
- Configured server to run on port 3000
- Implemented sample activity feed data with 3 mock entries

### How to test?
1. Start the server: `node server.js`
2. Send a GET request to `http://localhost:3000/feed`
3. Verify the response contains the mock activity feed data
4. Confirm server logs show "Server running on port 3000"

### Why make this change?
To provide a basic API endpoint for retrieving activity feed data, which will serve as a foundation for the activity feed feature in the application. This implementation allows frontend development to proceed with reliable test data.