### PR TITLE
Add server API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR
Created a new Express server with a search endpoint for task management.

### What changed?
- Implemented a new Express server on port 3000
- Added a `/search` endpoint that filters tasks based on description
- Created an initial set of mock task data with IDs and descriptions
- Implemented case-insensitive search functionality

### How to test?
1. Start the server: `node server.js`
2. Send GET requests to `http://localhost:3000/search` with a query parameter
3. Test different search scenarios:
   - No query: `GET /search` (returns all tasks)
   - With query: `GET /search?query=report` (returns matching tasks)
   - Case variations: `GET /search?query=MONTHLY` (should match regardless of case)

### Why make this change?
To provide a basic task search functionality that allows users to filter tasks based on their descriptions, making it easier to find specific tasks in the system.